### PR TITLE
Replace a space with tab in Makefile

### DIFF
--- a/mail/locales/Makefile.in
+++ b/mail/locales/Makefile.in
@@ -100,7 +100,7 @@ endif
 	@$(MAKE) -C ../../editor/ui/locales AB_CD=$* XPI_NAME=locale-$*
 	@$(MAKE) -C $(DEPTH)/extensions/spellcheck/locales AB_CD=$* XPI_NAME=locale-$*
 	@$(MAKE) -C $(DEPTH)/intl/locales AB_CD=$* XPI_NAME=locale-$*
- 	@$(MAKE) -B searchplugins AB_CD=$* XPI_NAME=locale-$*
+	@$(MAKE) -B searchplugins AB_CD=$* XPI_NAME=locale-$*
 	@$(MAKE) libs AB_CD=$* XPI_NAME=locale-$* PREF_DIR=defaults/pref
 	@$(MAKE) -C $(DEPTH)/$(MOZ_BRANDING_DIRECTORY)/locales AB_CD=$* XPI_NAME=locale-$*
 


### PR DESCRIPTION
Just what it says in the tin.

Allows the build system to successfully complete the export step when building Interlink on Linux.