### PR TITLE
Add global menubar support for GTK

### DIFF
--- a/mail/base/content/mailCore.js
+++ b/mail/base/content/mailCore.js
@@ -297,6 +297,11 @@ function onViewToolbarsPopupShowing(aEvent, toolboxIds, aInsertPoint)
       let toolbarName = toolbar.getAttribute("toolbarname");
       if (toolbarName) {
         if (toolbar.id == "mail-toolbar-menubar2") {
+#ifdef MOZ_WIDGET_GTK
+          if (document.documentElement.getAttribute("shellshowingmenubar") == "true") {
+            continue;
+          }
+#endif
           if (!mailToolbarMenubar) {
             mailToolbarMenubar = true;
           }

--- a/mail/base/jar.mn
+++ b/mail/base/jar.mn
@@ -38,7 +38,7 @@ messenger.jar:
 *   content/messenger/msgMail3PaneWindow.js         (content/msgMail3PaneWindow.js)
     content/messenger/mail3PaneWindowCommands.js    (content/mail3PaneWindowCommands.js)
     content/messenger/mailCommands.js               (content/mailCommands.js)
-    content/messenger/mailCore.js                   (content/mailCore.js)
+*   content/messenger/mailCore.js                   (content/mailCore.js)
     content/messenger/customizeToolbarOverlay.xul   (content/customizeToolbarOverlay.xul)
     content/messenger/mailTabs.js                   (content/mailTabs.js)
     content/messenger/commandglue.js                (content/commandglue.js)

--- a/navigator/comm/content/utilityOverlay.js
+++ b/navigator/comm/content/utilityOverlay.js
@@ -350,6 +350,11 @@ function onViewToolbarsPopupShowing(aEvent, aInsertPoint)
                                       function(toolbar) {
                                         return toolbar.hasAttribute("toolbarname")});
   var toolbars = Array.slice(toolbox.getElementsByAttribute("toolbarname", "*"));
+#ifdef MOZ_WIDGET_GTK
+  if (document.documentElement.getAttribute("shellshowingmenubar") == "true") {
+    toolbars = toolbars.filter(bar => bar.id !== "toolbar-menubar");
+  }
+#endif
   toolbars = toolbars.concat(externalToolbars);
   var menusep = document.getElementById("toolbarmode-sep");
 

--- a/navigator/comm/jar.mn
+++ b/navigator/comm/jar.mn
@@ -40,7 +40,7 @@ comm.jar:
   content/communicator/sanitize.xul                                (content/sanitize.xul)  
   content/communicator/tasksOverlay.js                             (content/tasksOverlay.js)
   content/communicator/tasksOverlay.xul                            (content/tasksOverlay.xul)
-  content/communicator/utilityOverlay.js                           (content/utilityOverlay.js)
+* content/communicator/utilityOverlay.js                           (content/utilityOverlay.js)
   content/communicator/utilityOverlay.xul                          (content/utilityOverlay.xul)
   content/communicator/viewSourceOverlay.js                        (content/viewSourceOverlay.js)
   content/communicator/viewSourceOverlay.xul                       (content/viewSourceOverlay.xul)

--- a/navigator/components/bookmarks/content/bookmarksManager.xul
+++ b/navigator/components/bookmarks/content/bookmarksManager.xul
@@ -125,7 +125,12 @@
     <toolbar id="placesToolbar"
              class="chromeclass-toolbar"
              align="center">
+#ifdef MOZ_WIDGET_GTK
+      <menubar id="placesMenu" 
+             _moz-menubarkeeplocal="true">
+#else
       <menubar id="placesMenu">
+#endif
         <menu id="menu_File">
           <menupopup id="menu_FilePopup">
             <menuitem id="newbookmark"

--- a/navigator/components/bookmarks/jar.mn
+++ b/navigator/components/bookmarks/jar.mn
@@ -11,7 +11,7 @@ comm.jar:
   content/communicator/bookmarks/bm-props.xul                      (content/bm-props.xul)
   content/communicator/bookmarks/bookmarksManager.css              (content/bookmarksManager.css)
   content/communicator/bookmarks/bookmarksManager.js               (content/bookmarksManager.js)
-  content/communicator/bookmarks/bookmarksManager.xul              (content/bookmarksManager.xul)
+* content/communicator/bookmarks/bookmarksManager.xul              (content/bookmarksManager.xul)
   content/communicator/bookmarks/browser-places.js                 (content/browser-places.js)
   content/communicator/bookmarks/editBookmarkOverlay.js            (content/editBookmarkOverlay.js)
   content/communicator/bookmarks/editBookmarkOverlay.xul           (content/editBookmarkOverlay.xul)

--- a/navigator/components/history/content/history.xul
+++ b/navigator/components/history/content/history.xul
@@ -68,6 +68,9 @@
     <toolbar id="placesToolbar"
              type="menubar">
       <menubar id="history-menu"
+#ifdef MOZ_WIDGET_GTK
+               _moz-menubarkeeplocal="true"
+#endif
                grippytooltiptext="&menuBar.tooltip;">
 
         <menu id="menu_File">

--- a/navigator/components/history/jar.mn
+++ b/navigator/components/history/jar.mn
@@ -6,7 +6,7 @@
 comm.jar:
   content/communicator/history/controller.js                       (content/controller.js)
   content/communicator/history/history.js                          (content/history.js)
-  content/communicator/history/history.xul                         (content/history.xul)
+* content/communicator/history/history.xul                         (content/history.xul)
   content/communicator/history/history-panel.xul                   (content/history-panel.xul)
   content/communicator/history/places.css                          (content/places.css)
   content/communicator/history/placesOverlay.xul                   (content/placesOverlay.xul)


### PR DESCRIPTION
Tag MoonchildProductions/UXP#1578

This adds the plumbing to both `mail` and `navigator` to hide the menu bar context menu toggle when required, and in the case of `navigator` also makes sure that the menubars in both the history manager and bookmarks manager don't get exported as that would either remove the searchbar (in the case of history) or leave a gap where the menubar was (in the case of bookmarks - as there's still a searchbar there).